### PR TITLE
build indexing Plugin in CI (4-2-stable)

### DIFF
--- a/document_type.cmake
+++ b/document_type.cmake
@@ -34,6 +34,7 @@ target_include_directories(
     ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
     ${IRODS_EXTERNALS_FULLPATH_JSON}/include
     ${IRODS_EXTERNALS_FULLPATH_JANSSON}/include
+    ${IRODS_EXTERNALS_FULLPATH_FMT}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
 

--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -57,14 +57,18 @@ def install_os_specific_dependencies():
     except KeyError:
         irods_python_ci_utilities.raise_not_implemented_for_distribution()
 
+
 def install_irods_dev_and_runtime_packages(irods_packages_root_directory):
+
     irods_packages_directory = irods_python_ci_utilities.append_os_specific_directory(irods_packages_root_directory)
-    dev_package_basename = filter(lambda x:'irods-dev' in x, os.listdir(irods_packages_directory))[0]
-    dev_package = os.path.join(irods_packages_directory, dev_package_basename)
-    irods_python_ci_utilities.install_os_packages_from_files([dev_package])
+# starting in iRODS 4.2.11 , irods-dev has a dependency on irods-runtime
     runtime_package_basename = filter(lambda x:'irods-runtime' in x, os.listdir(irods_packages_directory))[0]
     runtime_package = os.path.join(irods_packages_directory, runtime_package_basename)
     irods_python_ci_utilities.install_os_packages_from_files([runtime_package])
+
+    dev_package_basename = filter(lambda x:'irods-dev' in x, os.listdir(irods_packages_directory))[0]
+    dev_package = os.path.join(irods_packages_directory, dev_package_basename)
+    irods_python_ci_utilities.install_os_packages_from_files([dev_package])
 
 def copy_output_packages(build_directory, output_root_directory):
     irods_python_ci_utilities.gather_files_satisfying_predicate(

--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -12,7 +12,7 @@ def Indexing_PackageName_Regex( package_ext, technology = 'elasticsearch' ):
     tech = re.escape(technology)
     ext = re.escape(package_ext)
     return re.compile(
-        r'irods-rule-engine-plugin-(document-type|{tech}|indexing)-[0-9].*\.{ext}$'.format(**locals())
+        r'irods-rule-engine-plugin-(document-type|{tech}|indexing)[-_][0-9].*\.{ext}$'.format(**locals())
     )
 
 def get_matching_packages(directory,ext):


### PR DESCRIPTION
Allow plugin to build against irods 4.2.11.
   - `irods_query.hpp` now includes `fmt/format.h`
   - irods-dev{el} now depends on irods-runtime