### PR TITLE
[irods#6286] catch all exceptions.(4-2-stable)

### DIFF
--- a/libirods_rule_engine_plugin-indexing.cpp
+++ b/libirods_rule_engine_plugin-indexing.cpp
@@ -936,7 +936,20 @@ irods::error exec_rule_text(
                 _e.code(),
                 _e.what());
     }
-
+    catch(const std::exception & _e) {
+        rodsLog(LOG_ERROR,"std::exception (%s) in FILE %s LINE %d FUNCTION %s ",
+                            _e.what(),__FILE__,__LINE__,__FUNCTION__);
+        return ERROR(
+                SYS_NOT_SUPPORTED,
+                _e.what());
+    }
+    catch(...) {
+        rodsLog(LOG_ERROR,"Unknown error in FILE %s LINE %d FUNCTION %s ",
+                            __FILE__,__LINE__,__FUNCTION__);
+        return ERROR(
+                SYS_NOT_SUPPORTED,
+                "Unknown error");
+    }
     return SUCCESS();
 } // exec_rule_text
 
@@ -1141,6 +1154,20 @@ irods::error exec_rule_expression(
         return ERROR(
                 _e.code(),
                 _e.what());
+    }
+    catch(const std::exception & _e) {
+        rodsLog(LOG_ERROR,"std::exception (%s) in FILE %s LINE %d FUNCTION %s ",
+                            _e.what(),__FILE__,__LINE__,__FUNCTION__);
+        return ERROR(
+                SYS_NOT_SUPPORTED,
+                _e.what());
+    }
+    catch(...) {
+        rodsLog(LOG_ERROR,"Unknown error in FILE %s LINE %d FUNCTION %s ",
+                            __FILE__,__LINE__,__FUNCTION__);
+        return ERROR(
+                SYS_NOT_SUPPORTED,
+                "Unknown error");
     }
 
     return SUCCESS();


### PR DESCRIPTION
Even nlohmann::json errors will be caught and logged in an informative
way, since the embedded message conveys their code and type.