### PR TITLE
[162, 163] Fix build and test hooks (main)

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -15,9 +15,8 @@ def add_cmake_to_front_of_path():
 
 def install_building_dependencies(externals_directory):
     externals_list = [
-        'irods-externals-boost1.81.0-0',
-        'irods-externals-clang-runtime13.0.0-0',
-        'irods-externals-clang13.0.0-0',
+        'irods-externals-boost1.81.0-1',
+        'irods-externals-clang13.0.1-0',
         'irods-externals-cmake3.21.4-0',
         'irods-externals-json3.10.4-0'
     ]

--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -162,8 +162,6 @@ def main():
     if options.do_setup:
         install_build_prerequisites()
 
-        irods_python_ci_utilities.subprocess_get_output(['sudo', '-EH', 'python3', '-m', 'pip', 'install', 'unittest-xml-reporting==1.14.0'])
-
         install_indexing_engine(options.indexing_engine)
 
         # Packages are put either in top level or os-specific subdirectory.


### PR DESCRIPTION
Do not install unittest-xml-reporting==1.14.0
Update versions of externals packages in build hook
