### PR TITLE
[irods/irods#7547,irods/externals#263] Update build hook for Clang 16, do not use UseLibCXX (main)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ project(irods_capability-indexing
 include("${IRODS_TARGETS_PATH}")
 
 include(GNUInstallDirs)
-include(UseLibCXX)
 
 if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build {Debug, Release}." FORCE)

--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -15,8 +15,8 @@ def add_cmake_to_front_of_path():
 
 def install_building_dependencies(externals_directory):
     externals_list = [
-        'irods-externals-boost1.81.0-1',
-        'irods-externals-clang13.0.1-0',
+        'irods-externals-boost1.81.0-2',
+        'irods-externals-clang16.0.6-0',
         'irods-externals-cmake3.21.4-0',
         'irods-externals-json3.10.4-0'
     ]


### PR DESCRIPTION
In service of irods/irods#7547
In service of irods/externals#263

Do not merge before new externals packages are in the package repos.